### PR TITLE
Add multiple Bixi stations and cycle through display

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -417,7 +417,7 @@ footer {
 }
 #bixi-card .text {
     text-align: left;
-    margin-left: 220px;
+    margin-left: 200px;
 }
 
 /* -- Directory card ------------------ */

--- a/src/components/bixicard.js
+++ b/src/components/bixicard.js
@@ -5,22 +5,29 @@ let strings = new LocalizedStrings({
     en: {
         'theres': 'There are',
         'bikes': ' Bixi bicycle',
-        'available': ' available at Milton/Clark'
+        'available': ' at '
     },
     fr: {
         'theres': 'Il y a',
         'bikes': 'vélo',
-        'available': ' Bixi disponible à Milton/Clark'
+        'available': ' Bixi à '
     }
 });
+
+// milton/clark station 6209
+// clark/evans station 6003
+// Ste-Famille/Sherbrooke 6202
+let stationList = ["6209", "6003", "6202"];
 
 export default class BixiCard extends React.Component {
 
     constructor(props) {
         super(props);
         this.state = {
-            //data: [],
+            stationData: [],
             bikesAvailable: 0,
+            station: '',
+            cycleCount: 0,
         };
         this.updateBixi = this.updateBixi.bind(this);
     }
@@ -35,19 +42,29 @@ export default class BixiCard extends React.Component {
             return res.json();
         })
         .then(res => {
+            let stationArray = [];
             res.stations.filter(function(station){
-                // milton/clark station 6209
-                return station.n === "6209";
+                return stationList.indexOf(station.n) > -1;
             }).forEach(function(station){
-                // set state of bikes available
-                scope.setState({bikesAvailable: station.ba});
+                stationArray.push(station);
             });
+            scope.setState({stationData: stationArray});
+            this.cycleBixi();
         }).catch(err => {
             scope.setState({
                 bikesAvailable: -1
             });
             console.log('Bixi error '+err);
         });
+    }
+
+    cycleBixi() {
+        let i = this.state.cycleCount;
+        let arr = this.state.stationData;
+        (i+1<arr.length?++i:i=0);
+        this.setState({cycleCount: i});
+        this.setState({bikesAvailable: this.state.stationData[i].ba});
+        this.setState({station: this.state.stationData[i].s});
     }
 
     componentWillMount() {
@@ -57,7 +74,7 @@ export default class BixiCard extends React.Component {
     componentDidMount() {
         window.setInterval(function(){
             this.updateBixi();
-        }.bind(this), 60000);
+        }.bind(this), 20000);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -70,7 +87,7 @@ export default class BixiCard extends React.Component {
         let message = '';
 
         if (bikesAvailable > -1) {
-            message = `${bikesAvailable} ${strings.bikes}${bikesAvailable === 1?'':'s'} ${strings.available}`;
+            message = `${bikesAvailable} ${strings.bikes}${bikesAvailable === 1?'':'s'} ${strings.available}${this.state.station}`;
         } else {
             message = 'Unable to get bike availabilty';
         }

--- a/src/components/bixicard.js
+++ b/src/components/bixicard.js
@@ -30,6 +30,7 @@ export default class BixiCard extends React.Component {
             cycleCount: 0,
         };
         this.updateBixi = this.updateBixi.bind(this);
+        //this.cycleBixi = this.cycleBixi.bind(this);
     }
 
     updateBixi() {
@@ -49,7 +50,14 @@ export default class BixiCard extends React.Component {
                 stationArray.push(station);
             });
             scope.setState({stationData: stationArray});
+            return;
+        })
+        .then( () => {
+            clearInterval(cycleInterval);
             this.cycleBixi();
+            let cycleInterval = window.setInterval(function(){
+                this.cycleBixi();
+            }.bind(this), 20000);
         }).catch(err => {
             scope.setState({
                 bikesAvailable: -1
@@ -59,12 +67,16 @@ export default class BixiCard extends React.Component {
     }
 
     cycleBixi() {
-        let i = this.state.cycleCount;
-        let arr = this.state.stationData;
-        (i+1<arr.length?++i:i=0);
-        this.setState({cycleCount: i});
-        this.setState({bikesAvailable: this.state.stationData[i].ba});
-        this.setState({station: this.state.stationData[i].s});
+        let cycleCount = this.state.cycleCount;
+        let stationData = this.state.stationData;
+        if (cycleCount+1 < stationData.length){
+            ++cycleCount;
+        } else {
+            cycleCount = 0;
+        }
+        this.setState({cycleCount: cycleCount});
+        this.setState({bikesAvailable: this.state.stationData[cycleCount].ba});
+        this.setState({station: this.state.stationData[cycleCount].s});
     }
 
     componentWillMount() {
@@ -74,7 +86,7 @@ export default class BixiCard extends React.Component {
     componentDidMount() {
         window.setInterval(function(){
             this.updateBixi();
-        }.bind(this), 20000);
+        }.bind(this), 60000);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -90,6 +102,7 @@ export default class BixiCard extends React.Component {
             message = `${bikesAvailable} ${strings.bikes}${bikesAvailable === 1?'':'s'} ${strings.available}${this.state.station}`;
         } else {
             message = 'Unable to get bike availabilty';
+            console.log('unavailable');
         }
 
         return(

--- a/src/components/bixicard.js
+++ b/src/components/bixicard.js
@@ -74,9 +74,10 @@ export default class BixiCard extends React.Component {
         } else {
             cycleCount = 0;
         }
-        this.setState({cycleCount: cycleCount});
-        this.setState({bikesAvailable: this.state.stationData[cycleCount].ba});
-        this.setState({station: this.state.stationData[cycleCount].s});
+        this.setState({
+            cycleCount: cycleCount,
+            bikesAvailable: this.state.stationData[cycleCount].ba,
+            station: this.state.stationData[cycleCount].s});
     }
 
     componentWillMount() {
@@ -113,5 +114,9 @@ export default class BixiCard extends React.Component {
                 </div>
             </div>
         );
+    }
+
+    componentWillUnmount() {
+        this.clearInterval(this.interval);
     }
 }


### PR DESCRIPTION
This update allows an array of Bixi stations to be passed to the display. 
The card will cycle through the array, displaying bike availability at each given location.